### PR TITLE
refactor: split game screen into hooks and components

### DIFF
--- a/src/components/ParticipantStats.tsx
+++ b/src/components/ParticipantStats.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { Participant } from '../types';
+import ScoreCard from './ScoreCard';
+
+interface ParticipantStatsProps {
+  participants: Participant[];
+  currentIndex: number;
+}
+
+const ParticipantStats: React.FC<ParticipantStatsProps> = ({ participants, currentIndex }) => {
+  return (
+    <div className="absolute top-8 left-8 flex gap-6 items-center z-40">
+      <img src="img/bee.svg" alt="Bee icon" className="w-16 h-16 animate-wiggle" />
+      {participants.map((p, index) => (
+        <ScoreCard key={index} participant={p} isActive={index === currentIndex} />
+      ))}
+    </div>
+  );
+};
+
+export default ParticipantStats;

--- a/src/hooks/useGameTimer.ts
+++ b/src/hooks/useGameTimer.ts
@@ -1,0 +1,13 @@
+import useTimer from '../utils/useTimer';
+import useSound from '../utils/useSound';
+import timeoutSoundFile from '../audio/timeout.mp3';
+
+const useGameTimer = (duration: number, soundEnabled: boolean, onExpire: () => void) => {
+  const playTimeout = useSound(timeoutSoundFile, soundEnabled);
+  return useTimer(duration, () => {
+    playTimeout();
+    onExpire();
+  });
+};
+
+export default useGameTimer;

--- a/src/hooks/useWordProgression.ts
+++ b/src/hooks/useWordProgression.ts
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Word } from '../types';
+import useWordSelection from '../utils/useWordSelection';
+
+const useWordProgression = (wordDatabase: Word[]) => {
+  const { wordQueues, setWordQueues, currentWord, currentDifficulty, selectNextWord } =
+    useWordSelection(wordDatabase);
+
+  const selectNextWordForLevel = React.useCallback(
+    (level: number) => {
+      return selectNextWord(level);
+    },
+    [selectNextWord]
+  );
+
+  return { wordQueues, setWordQueues, currentWord, currentDifficulty, selectNextWordForLevel };
+};
+
+export default useWordProgression;


### PR DESCRIPTION
## Summary
- extract timer sound and expiry handling into reusable `useGameTimer` hook
- centralize word progression logic in `useWordProgression`
- factor participant stats and help shop into dedicated components and orchestrate in `GameScreen`

## Testing
- `npm test` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68c6be8a27108332943378e2f9b534b0