### PR TITLE
feat: add configurable logger utility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,7 @@ ELEVENLABS_API_KEY=your_elevenlabs_api_key_here
 # Audio Generation Settings
 AUDIO_OUTPUT_DIR=public/audio
 AUDIO_VOICE_ID=21m00Tcm4TlvDq8ikWAM  # Rachel's voice - clear and friendly
+
+# Logging
+# Set LOG_LEVEL to control verbosity: debug, info, warn, error
+LOG_LEVEL=info

--- a/src/utils/audioManager.ts
+++ b/src/utils/audioManager.ts
@@ -1,5 +1,6 @@
 // Audio Manager Implementation
 import { Howl, Howler } from 'howler';
+import logger from './logger';
 
 const ensureAudioContext = () => {
   // Howler automatically creates context when needed
@@ -83,10 +84,10 @@ class AudioManager {
       volume,
       preload,
       onload: () => {
-        console.log(`Sound loaded: ${key}`);
+        logger.info(`Sound loaded: ${key}`);
       },
       onloaderror: (_, error) => {
-        console.error(`Error loading sound ${key}:`, error);
+        logger.error(`Error loading sound ${key}:`, error);
         if (onerror) onerror(new Error(`Failed to load sound: ${key}`));
       },
       onend: () => {
@@ -94,7 +95,7 @@ class AudioManager {
       },
       onplayerror: () => {
         const error = new Error(`Failed to play sound: ${key}`);
-        console.error(error.message);
+        logger.error(error.message);
         if (onerror) onerror(error);
       },
     });
@@ -175,7 +176,7 @@ class AudioManager {
       // If still not found, try to load it
       if (!sound) {
         this.loadSound(keyOrPath, keyOrPath, { ...options, preload: true });
-        console.warn(`Sound not preloaded: ${keyOrPath}, attempting to load...`);
+        logger.warn(`Sound not preloaded: ${keyOrPath}, attempting to load...`);
         return null;
       }
     }
@@ -247,10 +248,10 @@ class AudioManager {
       volume: this.settings.musicVolume,
       preload,
       onload: () => {
-        console.log(`Music loaded: ${key}`);
+        logger.info(`Music loaded: ${key}`);
       },
       onloaderror: (_, error) => {
-        console.error(`Error loading music ${key}:`, error);
+        logger.error(`Error loading music ${key}:`, error);
         if (onerror) onerror(new Error(`Failed to load music: ${key}`));
       },
       onend: () => {
@@ -258,7 +259,7 @@ class AudioManager {
       },
       onplayerror: () => {
         const error = new Error(`Failed to play music: ${key}`);
-        console.error(error.message);
+        logger.error(error.message);
         if (onerror) onerror(error);
       },
     });
@@ -284,7 +285,7 @@ class AudioManager {
     const music = this.music.get(key);
 
     if (!music) {
-      console.error(`Music not found: ${key}`);
+      logger.error(`Music not found: ${key}`);
       if (onerror) onerror(new Error(`Music not found: ${key}`));
       return null;
     }
@@ -402,7 +403,7 @@ class AudioManager {
         }
       }
     } catch (error) {
-      console.error('Error loading audio settings:', error);
+      logger.error('Error loading audio settings:', error);
     }
   }
 
@@ -413,7 +414,7 @@ class AudioManager {
     try {
       localStorage.setItem('audioSettings', JSON.stringify(this.settings));
     } catch (error) {
-      console.error('Error saving audio settings:', error);
+      logger.error('Error saving audio settings:', error);
     }
   }
 }

--- a/src/utils/elevenlabs.ts
+++ b/src/utils/elevenlabs.ts
@@ -1,4 +1,5 @@
 import { mcp0_text_to_speech } from '../../mcp/elevenlabs';
+import logger from './logger';
 
 interface ElevenLabsOptions {
   voiceId?: string;
@@ -45,7 +46,7 @@ export async function generateSpeech(
     
     return null;
   } catch (error) {
-    console.error('Error generating speech:', error);
+    logger.error('Error generating speech:', error);
     return null;
   }
 }
@@ -78,7 +79,7 @@ export async function saveAudioToFile(
     await fs.writeFile(filePath, Buffer.from(result.audioData));
     return true;
   } catch (error) {
-    console.error(`Error saving audio to ${filePath}:`, error);
+    logger.error(`Error saving audio to ${filePath}:`, error);
     return false;
   }
 }
@@ -105,18 +106,18 @@ export async function generateWordAudioFiles(
       // Skip if file already exists
       try {
         await fs.access(filePath);
-        console.log(`Skipping ${word} - already exists`);
+        logger.info(`Skipping ${word} - already exists`);
         return;
       } catch {
         // File doesn't exist, generate it
       }
       
-      console.log(`Generating audio for: ${word}`);
+      logger.info(`Generating audio for: ${word}`);
       const success = await saveAudioToFile(word, filePath, options);
       if (success) {
-        console.log(`Generated: ${filePath}`);
+        logger.info(`Generated: ${filePath}`);
       } else {
-        console.error(`Failed to generate: ${word}`);
+        logger.error(`Failed to generate: ${word}`);
       }
       
       // Add a small delay between requests

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,42 @@
+type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+const levels: Record<LogLevel, number> = {
+  error: 0,
+  warn: 1,
+  info: 2,
+  debug: 3,
+};
+
+const env = (typeof process !== 'undefined' && (process as any).env) || {};
+
+const envLevel = (env.LOG_LEVEL || '').toLowerCase() as LogLevel;
+
+const defaultLevel: LogLevel = env.NODE_ENV === 'production' ? 'warn' : 'info';
+
+const currentLevel: LogLevel = levels[envLevel] !== undefined ? envLevel : defaultLevel;
+
+function shouldLog(level: LogLevel): boolean {
+  return levels[level] <= levels[currentLevel];
+}
+
+function log(level: LogLevel, ...args: any[]): void {
+  if (!shouldLog(level)) return;
+  const method =
+    level === 'debug'
+      ? console.debug
+      : level === 'info'
+      ? console.log
+      : level === 'warn'
+      ? console.warn
+      : console.error;
+  method(...args);
+}
+
+const logger = {
+  debug: (...args: any[]) => log('debug', ...args),
+  info: (...args: any[]) => log('info', ...args),
+  warn: (...args: any[]) => log('warn', ...args),
+  error: (...args: any[]) => log('error', ...args),
+};
+
+export default logger;


### PR DESCRIPTION
## Summary
- add simple logger utility with level filtering
- replace console logs in elevenlabs and audio manager with logger
- document LOG_LEVEL env to control verbosity

## Testing
- `npm test` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68c6be9098c883329e6549d1696802a0