### PR TITLE
feat: make word list service configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,8 @@ This project includes scripts to generate high-quality audio files using ElevenL
 3. Create a `.env` file with the following content:
    ```
    GITHUB_TOKEN=your_token_here
+   # optional: override the word list generation endpoint
+   VITE_WORDLIST_URL=http://localhost:3001/generate-word-list
    ```
 4. Run `npm start` to start the development server
 

--- a/build.js
+++ b/build.js
@@ -8,7 +8,7 @@ if (!fs.existsSync('dist')) {
 
 // Run esbuild
 console.log('Building application...');
-execSync(`npx esbuild src/spelling-bee-game.tsx --bundle --outfile=dist/app.js --jsx=automatic --target=es2020 --format=esm --loader:.mp3=file --loader:.svg=file --loader:.png=file --loader:.jpg=file --loader:.jpeg=file --define:process.env.NODE_ENV='"production"' --define:process.env.PUBLIC_URL='""' --define:process.env.GITHUB_TOKEN='""' --define:process.env.GITHUB_MODELS_TOKEN='""' --define:process.env.API_TOKEN='""'`, { stdio: 'inherit' });
+execSync(`npx esbuild src/spelling-bee-game.tsx --bundle --outfile=dist/app.js --jsx=automatic --target=es2020 --format=esm --loader:.mp3=file --loader:.svg=file --loader:.png=file --loader:.jpg=file --loader:.jpeg=file --define:process.env.NODE_ENV='"production"' --define:process.env.PUBLIC_URL='""' --define:process.env.GITHUB_TOKEN='""' --define:process.env.GITHUB_MODELS_TOKEN='""' --define:process.env.API_TOKEN='""' --define:process.env.VITE_WORDLIST_URL='""'`, { stdio: 'inherit' });
 
 // Build Tailwind CSS
 console.log('Building Tailwind CSS...');

--- a/src/api/githubAIService.ts
+++ b/src/api/githubAIService.ts
@@ -1,5 +1,9 @@
+const WORDLIST_URL =
+  process.env.VITE_WORDLIST_URL ||
+  'http://localhost:3001/generate-word-list';
+
 export async function generateWordList(prompt: string): Promise<string> {
-  const response = await fetch('http://localhost:3001/generate-word-list', {
+  const response = await fetch(WORDLIST_URL, {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',


### PR DESCRIPTION
## Summary
- load word list service URL from `VITE_WORDLIST_URL` instead of hardcoding
- inject word list URL into build process
- document `VITE_WORDLIST_URL` in setup instructions

## Testing
- `npm test` *(fails: 15 failed)*

------
https://chatgpt.com/codex/tasks/task_e_68c6be8abad48332b2d39da2c781c5da