### PR TITLE
Add unit and Playwright tests for core gameplay features

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "node build.js",
     "watch": "npx esbuild src/spelling-bee-game.tsx --bundle --outfile=dist/app.js --jsx=automatic --watch",
     "test": "npm run test:unit && npm run test:e2e",
-    "test:unit": "node --test tests/history.test.js tests/parseWordList.test.js",
+    "test:unit": "node --test tests/history.test.js tests/parseWordList.test.js tests/helpShop.test.js tests/useTimer.test.js tests/achievement.test.js",
     "test:e2e": "playwright test",
     "test:e2e:install": "npx playwright install --with-deps && npm run test:e2e",
     "test:ui": "playwright test --ui",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,7 @@ dotenv.config({ path: path.resolve(__dirname, '.env') });
  */
 export default defineConfig({
   testDir: './tests',
+  testMatch: /.*\.playwright\.test\.[tj]s$/,
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/tests/achievement.test.js
+++ b/tests/achievement.test.js
@@ -1,0 +1,24 @@
+process.env.TS_NODE_COMPILER_OPTIONS = '{"module":"commonjs"}';
+process.env.TS_NODE_IGNORE_DIAGNOSTICS = '2664';
+require('ts-node/register');
+const { test } = require('node:test');
+const assert = require('assert');
+const { defaultAchievements } = require('../src/types.ts');
+
+test('unlocks achievements when thresholds met', () => {
+  const participant = { wordsCorrect: 55 };
+  const unlocked = [];
+  const newlyUnlocked = defaultAchievements.filter(
+    ach => participant.wordsCorrect >= ach.threshold && !unlocked.includes(ach.id)
+  );
+  assert.deepStrictEqual(newlyUnlocked.map(a => a.id), ['ten-words', 'fifty-words']);
+});
+
+test('skips already unlocked achievements', () => {
+  const participant = { wordsCorrect: 60 };
+  const unlocked = ['ten-words'];
+  const newlyUnlocked = defaultAchievements.filter(
+    ach => participant.wordsCorrect >= ach.threshold && !unlocked.includes(ach.id)
+  );
+  assert.deepStrictEqual(newlyUnlocked.map(a => a.id), ['fifty-words']);
+});

--- a/tests/features.playwright.test.js
+++ b/tests/features.playwright.test.js
@@ -1,0 +1,24 @@
+const { test, expect } = require('@playwright/test');
+
+test('team mode shows team roster', async ({ page }) => {
+  await page.goto('/');
+  await page.getByRole('button', { name: /TEAM BATTLE/i }).click();
+  await expect(page.getByText(/TEAM ROSTER/i)).toBeVisible();
+});
+
+test('hint purchase deducts coins', async ({ page }) => {
+  await page.goto('/shop');
+  await page.evaluate(() => localStorage.setItem('coins', '50'));
+  await page.reload();
+  await page.getByRole('button', { name: 'Buy Hint: Reveal a Letter' }).click();
+  await expect(page.getByText('30 coins')).toBeVisible();
+});
+
+test('leaderboard reflects stored scores', async ({ page }) => {
+  await page.goto('/leaderboard');
+  await page.evaluate(() => {
+    localStorage.setItem('leaderboard', JSON.stringify([{ name: 'Alice', score: 42, date: '2024-01-01' }]));
+  });
+  await page.reload();
+  await expect(page.getByText('Alice')).toBeVisible();
+});

--- a/tests/helpShop.test.js
+++ b/tests/helpShop.test.js
@@ -1,0 +1,46 @@
+process.env.TS_NODE_COMPILER_OPTIONS = '{"module":"commonjs"}';
+require('ts-node/register');
+const { JSDOM } = require('jsdom');
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+global.navigator = dom.window.navigator;
+
+const React = require('react');
+const { render, fireEvent, cleanup } = require('@testing-library/react');
+const { test } = require('node:test');
+const assert = require('assert');
+
+const { HelpShop } = require('../src/components/HelpShop.tsx');
+const { HelpSystemProvider } = require('../src/contexts/HelpSystemContext.tsx');
+
+test('deducts points when purchasing help item', () => {
+  let coins = 20;
+  const onPurchase = cost => {
+    coins -= cost;
+  };
+  const { getByText, getAllByText } = render(
+    React.createElement(HelpSystemProvider, null,
+      React.createElement(HelpShop, { onClose: () => {}, coins, onPurchase })
+    )
+  );
+  fireEvent.click(getByText('10 pts'));
+  assert.strictEqual(coins, 10);
+  cleanup();
+});
+
+test('does not purchase when coins insufficient', () => {
+  let coins = 5;
+  const onPurchase = cost => {
+    coins -= cost;
+  };
+  const { getAllByText } = render(
+    React.createElement(HelpSystemProvider, null,
+      React.createElement(HelpShop, { onClose: () => {}, coins, onPurchase })
+    )
+  );
+  const button = getAllByText('10 pts')[0];
+  fireEvent.click(button);
+  assert.strictEqual(coins, 5);
+  cleanup();
+});

--- a/tests/useTimer.test.js
+++ b/tests/useTimer.test.js
@@ -1,0 +1,29 @@
+process.env.TS_NODE_COMPILER_OPTIONS = '{"module":"commonjs"}';
+require('ts-node/register');
+const { JSDOM } = require('jsdom');
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+global.navigator = dom.window.navigator;
+
+const React = require('react');
+const { render } = require('@testing-library/react');
+const { test } = require('node:test');
+const assert = require('assert');
+const useTimer = require('../src/utils/useTimer.ts').default;
+
+test('calls onExpire when timer runs out', async () => {
+  let expired = false;
+  const Comp = () => {
+    const timer = useTimer(1, () => {
+      expired = true;
+    });
+    React.useEffect(() => {
+      timer.start();
+    }, [timer]);
+    return null;
+  };
+  render(React.createElement(Comp));
+  await new Promise(r => setTimeout(r, 1100));
+  assert.ok(expired);
+});


### PR DESCRIPTION
## Summary
- add unit tests covering help shop deductions, timer expiration, and achievement unlocking
- expand Playwright coverage for team mode, hint purchases, and leaderboard updates
- update test scripts and Playwright config for CI compatibility

## Testing
- `npm run test:unit`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/chromium_headless_shell-1187/chrome-linux/headless_shell)*

------
https://chatgpt.com/codex/tasks/task_e_68c6be91b2b88332a3985007dcd18a55