### PR TITLE
feat: improve BeeButton focus and ripple effects

### DIFF
--- a/src/components/BeeButton.tsx
+++ b/src/components/BeeButton.tsx
@@ -8,6 +8,7 @@ interface BeeButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   leftIcon?: React.ReactNode;
   rightIcon?: React.ReactNode;
   isLoading?: boolean;
+  ripple?: boolean;
 }
 
 const BeeButton: React.FC<BeeButtonProps> = ({
@@ -18,11 +19,13 @@ const BeeButton: React.FC<BeeButtonProps> = ({
   leftIcon,
   rightIcon,
   isLoading = false,
+  ripple = false,
   className = '',
   disabled,
   ...props
 }) => {
-  const baseClasses = 'inline-flex items-center justify-center rounded-full transition-all duration-medium1 focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:opacity-38 disabled:pointer-events-none';
+  const baseClasses =
+    'inline-flex items-center justify-center rounded-full transition-all duration-medium1 focus:outline-none focus:ring-2 focus:ring-primary-500 focus-visible:ring-4 focus-visible:transition focus-visible:duration-short2 disabled:opacity-38 disabled:pointer-events-none';
   
   const sizeClasses = {
     sm: 'h-8 px-4 text-label-medium',
@@ -68,6 +71,8 @@ const BeeButton: React.FC<BeeButtonProps> = ({
         variantClasses[variant],
         isFullWidth && 'w-full',
         'relative',
+        ripple &&
+          'overflow-hidden after:content-[""] after:absolute after:inset-0 after:rounded-full after:bg-current after:opacity-0 after:transition-transform after:duration-short4 after:scale-0 active:after:opacity-20 active:after:scale-125',
         className
       )}
       disabled={disabled || isLoading}


### PR DESCRIPTION
## Summary
- add `focus-visible` ring and transition to BeeButton
- support optional click ripple effect using pseudo-element

## Testing
- `npm run test:unit`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist, run `npx playwright install`)*
- `npx playwright install` *(fails: download failed, server returned code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cb9cd4e08332a6cc1dd763b478a9