### PR TITLE
feat: make BeeCard decorations optional

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "build": "node build.js",
     "watch": "npx esbuild src/spelling-bee-game.tsx --bundle --outfile=dist/app.js --jsx=automatic --watch",
     "test": "npm run test:unit && npm run test:e2e",
-    "test:unit": "node --test tests/history.test.js tests/parseWordList.test.js tests/helpShop.test.js tests/useTimer.test.js tests/achievement.test.js",
+    "test:unit": "node --test tests/history.test.js tests/parseWordList.test.js tests/helpShop.test.js tests/useTimer.test.js tests/achievement.test.js tests/BeeCard.test.js",
     "test:e2e": "playwright test",
     "test:e2e:install": "npx playwright install --with-deps && npm run test:e2e",
     "test:ui": "playwright test --ui",

--- a/src/components/BeeCard.tsx
+++ b/src/components/BeeCard.tsx
@@ -9,6 +9,7 @@ interface BeeCardProps {
   padding?: 'none' | 'sm' | 'md' | 'lg';
   rounded?: 'none' | 'xs' | 'sm' | 'md' | 'lg' | 'xl';
   onClick?: () => void;
+  decorative?: boolean;
 }
 
 const BeeCard: React.FC<BeeCardProps> = ({
@@ -19,6 +20,7 @@ const BeeCard: React.FC<BeeCardProps> = ({
   padding = 'md',
   rounded = 'md',
   onClick,
+  decorative = false,
 }) => {
   const baseClasses = 'relative transition-all duration-medium1';
   
@@ -67,8 +69,12 @@ const BeeCard: React.FC<BeeCardProps> = ({
       onClick={onClick}
     >
       {/* Decorative elements */}
-      <div className="absolute top-0 right-0 w-32 h-32 -mr-16 -mt-16 bg-bee-yellow-400/10 rounded-full mix-blend-multiply filter blur-xl opacity-70 dark:opacity-30" />
-      <div className="absolute bottom-0 left-0 w-32 h-32 -ml-16 -mb-16 bg-primary-400/10 rounded-full mix-blend-multiply filter blur-xl opacity-70 dark:opacity-30" />
+      {decorative && (
+        <>
+          <div className="absolute top-0 right-0 w-32 h-32 -mr-16 -mt-16 bg-bee-yellow-400/10 rounded-full mix-blend-multiply filter blur-lg opacity-40 dark:opacity-20" />
+          <div className="absolute bottom-0 left-0 w-32 h-32 -ml-16 -mb-16 bg-primary-400/10 rounded-full mix-blend-multiply filter blur-lg opacity-40 dark:opacity-20" />
+        </>
+      )}
       
       {/* Content */}
       <div className="relative z-10">

--- a/tests/BeeCard.test.js
+++ b/tests/BeeCard.test.js
@@ -1,0 +1,29 @@
+process.env.TS_NODE_COMPILER_OPTIONS = '{"module":"commonjs"}';
+require('ts-node/register');
+const { JSDOM } = require('jsdom');
+const dom = new JSDOM('<!doctype html><html><body></body></html>');
+global.window = dom.window;
+global.document = dom.window.document;
+global.navigator = dom.window.navigator;
+
+const React = require('react');
+const { render } = require('@testing-library/react');
+const { test } = require('node:test');
+const assert = require('assert');
+const BeeCard = require('../src/components/BeeCard.tsx').default;
+
+test('renders decorations when decorative is true', () => {
+  const { container } = render(
+    React.createElement(BeeCard, { decorative: true }, React.createElement('div', null, 'content'))
+  );
+  const decorations = container.querySelectorAll('div.absolute');
+  assert.equal(decorations.length, 2);
+});
+
+test('omits decorations when decorative is false', () => {
+  const { container } = render(
+    React.createElement(BeeCard, null, React.createElement('div', null, 'content'))
+  );
+  const decorations = container.querySelectorAll('div.absolute');
+  assert.equal(decorations.length, 0);
+});


### PR DESCRIPTION
## Summary
- allow BeeCard to render decorative backgrounds only when a new `decorative` prop is true
- soften decoration visuals with reduced blur and opacity
- add unit tests for BeeCard decoration toggle

## Testing
- `npm run test:unit`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist)*
- `npx playwright install chromium` *(fails: Download failed: server returned code 403 body 'Forbidden')*

------
https://chatgpt.com/codex/tasks/task_e_68c6cb9d7f148332a34ede71df9c237c