### PR TITLE
Use fluid clamp-based typography for headings

### DIFF
--- a/src/HistoryScreen.tsx
+++ b/src/HistoryScreen.tsx
@@ -25,7 +25,7 @@ const HistoryScreen: React.FC<HistoryScreenProps> = ({ onBack }) => {
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-gray-700 to-gray-900 p-8 text-white text-center flex flex-col items-center justify-center font-body">
-      <h1 className="text-6xl font-bold mb-8 text-yellow-300 uppercase font-sans">📘 Session History</h1>
+      <h1 className="font-bold mb-8 text-yellow-300 uppercase font-sans">📘 Session History</h1>
       <div className="bg-white/10 p-8 rounded-lg w-full max-w-md">
         {history.length === 0 ? (
           <div className="text-xl">No session history.</div>

--- a/src/ResultsScreen.tsx
+++ b/src/ResultsScreen.tsx
@@ -138,8 +138,8 @@ const ResultsScreen: React.FC<ResultsScreenProps> = ({ results, onRestart, onVie
 
   return (
     <div className="min-h-screen bg-surface p-8 text-on-surface text-center flex flex-col items-center justify-center font-body">
-      <h1 className="text-4xl font-bold mb-4 text-primary uppercase font-sans">🏆 Game Over! 🏆</h1>
-      <h2 className="text-2xl mb-8 uppercase font-sans">{getWinnerMessage()}</h2>
+      <h1 className="font-bold mb-4 text-primary uppercase font-sans">🏆 Game Over! 🏆</h1>
+      <h2 className="mb-8 uppercase font-sans">{getWinnerMessage()}</h2>
 
       {results?.duration && (<div className="text-xl mb-6">Game Duration: {results.duration} seconds</div>)}
       
@@ -150,7 +150,7 @@ const ResultsScreen: React.FC<ResultsScreenProps> = ({ results, onRestart, onVie
       </div>
 
         <div className="bg-surface-container-high p-6 rounded-xl w-full max-w-2xl shadow-elevation-1">
-          <h3 className="text-2xl font-bold mb-4 uppercase font-sans">📊 Final Scores</h3>
+          <h3 className="font-bold mb-4 uppercase font-sans">📊 Final Scores</h3>
         {results && results.participants.map((p, index) => (
           <div key={index} className="text-left mb-4 p-3 rounded-lg bg-surface-container-low">
             <div className="flex items-center gap-3 mb-1">
@@ -184,7 +184,7 @@ const ResultsScreen: React.FC<ResultsScreenProps> = ({ results, onRestart, onVie
 
       {results.missedWords && results.missedWords.length > 0 && (
           <div className="bg-surface-container-high p-6 rounded-xl w-full max-w-2xl mt-8 shadow-elevation-1">
-            <h3 className="text-2xl font-bold mb-4 uppercase font-sans">❌ Missed Words</h3>
+            <h3 className="font-bold mb-4 uppercase font-sans">❌ Missed Words</h3>
           {results.missedWords.map((w, index) => (
             <div key={index} className="text-left mb-3 p-3 rounded-lg bg-surface-container-low">
               <span className="font-bold">{w.word}</span> - {w.definition}

--- a/style.css
+++ b/style.css
@@ -48,12 +48,12 @@ h1, h2, h3, h4, h5, h6 {
   text-transform: uppercase;
 }
 
-h1 { font-size: 2.5rem; }
-h2 { font-size: 2rem; }
-h3 { font-size: 1.75rem; }
-h4 { font-size: 1.5rem; }
-h5 { font-size: 1.25rem; }
-h6 { font-size: 1rem; }
+h1 { font-size: clamp(2rem, 5vw, 3rem); }
+h2 { font-size: clamp(1.75rem, 4.5vw, 2.5rem); }
+h3 { font-size: clamp(1.5rem, 4vw, 2rem); }
+h4 { font-size: clamp(1.25rem, 3.5vw, 1.75rem); }
+h5 { font-size: clamp(1rem, 3vw, 1.5rem); }
+h6 { font-size: clamp(0.875rem, 2.5vw, 1.25rem); }
 
 p {
   margin-bottom: var(--spacing-md);


### PR DESCRIPTION
## Summary
- apply `clamp()` for h1–h6 font sizes in global stylesheet
- remove fixed Tailwind font-size utilities on key headings to avoid conflicts

## Testing
- `npm run test:unit`
- `npm run test:e2e` *(fails: browserType.launch: Executable doesn't exist at /root/.cache/ms-playwright/...)*

------
https://chatgpt.com/codex/tasks/task_e_68c6cb9b80ac833294686830565952e5