### PR TITLE
Fix scoreboard heart overlap

### DIFF
--- a/src/components/ScoreCard.tsx
+++ b/src/components/ScoreCard.tsx
@@ -9,13 +9,24 @@ interface ScoreCardProps {
 const ScoreCard: React.FC<ScoreCardProps> = ({ participant, isActive }) => {
   return (
     <div
-      className={`text-center scorecard transition-transform ${
-        isActive ? 'border-2 border-yellow-300 rounded-lg shadow-lg scale-105' : ''
+      className={`scorecard transition-transform text-center rounded-2xl border border-white/20 bg-white/10 px-6 py-4 backdrop-blur-md ${
+        isActive ? 'border-yellow-300 shadow-lg scale-105' : 'shadow-md'
       }`}
     >
-      <div className="text-2xl font-bold">{participant.name}</div>
-      <div className="text-4xl font-bold text-yellow-300">{'❤️'.repeat(participant.lives)}</div>
-      <div className="text-xl font-bold text-green-400">{participant.points} pts</div>
+      <div className="text-2xl font-bold text-white drop-shadow-sm">{participant.name}</div>
+      <div
+        className="mt-2 flex flex-wrap justify-center gap-1 text-4xl leading-none"
+        aria-label={`${participant.lives} lives`}
+      >
+        {Array.from({ length: participant.lives }).map((_, index) => (
+          <span key={index} className="font-bold text-yellow-300">
+            ❤️
+          </span>
+        ))}
+      </div>
+      <div className="mt-2 text-xl font-bold text-green-300 drop-shadow-sm">
+        {participant.points} pts
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- render player lives as individual heart icons that can wrap within the score card
- refresh the score card styling to prevent overlap and improve readability

## Testing
- not run (UI change)


------
https://chatgpt.com/codex/tasks/task_e_68e58d960e208332873b76aaef5ab1f9