### PR TITLE
Fix background music playback and controls

### DIFF
--- a/src/__tests__/useMusic.test.ts
+++ b/src/__tests__/useMusic.test.ts
@@ -1,31 +1,95 @@
 import { renderHook } from '@testing-library/react-hooks';
+import { waitFor } from '@testing-library/react';
 import useMusic from '../utils/useMusic';
+import { audioManager } from '../utils/audio.ts';
+
+const mockHowl = {
+  on: jest.fn(),
+  off: jest.fn(),
+  playing: jest.fn().mockReturnValue(false),
+};
+
+jest.mock('../constants', () => ({
+  musicFiles: {
+    funk: 'funk.mp3',
+    funk_instrumental: 'funk-instrumental.mp3',
+  },
+  DEFAULT_STYLE: 'funk',
+}));
+
+jest.mock('../utils/audio.ts', () => ({
+  audioManager: {
+    setMusicVolume: jest.fn(),
+    getMusic: jest.fn(() => mockHowl),
+    loadMusic: jest.fn(),
+    playMusic: jest.fn().mockReturnValue(1),
+    pauseMusic: jest.fn(),
+    resumeMusic: jest.fn(),
+    stopMusic: jest.fn(),
+  },
+}));
 
 describe('useMusic', () => {
+  const mockedAudioManager = audioManager as jest.Mocked<typeof audioManager>;
+
   beforeEach(() => {
-    window.AudioContext = jest.fn().mockImplementation(() => ({
-      decodeAudioData: jest.fn()
-    }));
+    jest.clearAllMocks();
+    mockHowl.playing.mockReturnValue(false);
   });
 
-  it('should initialize audio context', async () => {
-    const { result } = renderHook(() => useMusic());
-    result.current.initAudio();
-    expect(result.current.getAudioContext()).toBeDefined();
+  it('loads and plays music when enabled', async () => {
+    renderHook(() => useMusic('Funk', 'vocal', 0.5, true, 'menu', true));
+
+    await waitFor(() => {
+      expect(mockedAudioManager.loadMusic).toHaveBeenCalledWith(
+        'funk',
+        'funk.mp3',
+        expect.objectContaining({ loop: true })
+      );
+      expect(mockedAudioManager.playMusic).toHaveBeenCalledWith(
+        'funk',
+        expect.objectContaining({ loop: true })
+      );
+    });
   });
 
-  it('should load audio successfully', async () => {
-    const { result } = renderHook(() => useMusic());
-    result.current.initAudio();
-    
-    const mockBuffer = {};
-    const mockDecode = jest.fn().mockResolvedValue(mockBuffer);
-    const mockFetch = jest.fn().mockResolvedValue({ arrayBuffer: jest.fn().mockResolvedValue(new ArrayBuffer(8)) });
-    
-    global.fetch = mockFetch;
-    (result.current.getAudioContext() as any).decodeAudioData = mockDecode;
-    
-    const buffer = await result.current.loadAudio('test.mp3');
-    expect(buffer).toBe(mockBuffer);
+  it('pauses music when sound is disabled', async () => {
+    const { rerender } = renderHook(
+      ({ enabled }) => useMusic('Funk', 'vocal', 0.5, enabled, 'menu', true),
+      { initialProps: { enabled: true } }
+    );
+
+    await waitFor(() => {
+      expect(mockedAudioManager.playMusic).toHaveBeenCalled();
+    });
+
+    rerender({ enabled: false });
+
+    await waitFor(() => {
+      expect(mockedAudioManager.pauseMusic).toHaveBeenCalled();
+    });
+  });
+
+  it('pauses and resumes when toggling playback', async () => {
+    const { rerender } = renderHook(
+      ({ playing }) => useMusic('Funk', 'vocal', 0.5, true, 'menu', playing),
+      { initialProps: { playing: true } }
+    );
+
+    await waitFor(() => {
+      expect(mockedAudioManager.playMusic).toHaveBeenCalled();
+    });
+
+    rerender({ playing: false });
+
+    await waitFor(() => {
+      expect(mockedAudioManager.pauseMusic).toHaveBeenCalled();
+    });
+
+    rerender({ playing: true });
+
+    await waitFor(() => {
+      expect(mockedAudioManager.resumeMusic).toHaveBeenCalled();
+    });
   });
 });

--- a/src/spelling-bee-game.tsx
+++ b/src/spelling-bee-game.tsx
@@ -8,6 +8,7 @@ import AchievementsScreen from './AchievementsScreen';
 import HistoryScreen from './HistoryScreen';
 import ShopScreen from './ShopScreen';
 import useMusic from './utils/useMusic';
+import { audioManager } from './utils/audio.ts';
 import { AudioProvider } from './AudioContext';
 import { HelpSystemProvider } from './contexts/HelpSystemContext';
 
@@ -116,7 +117,29 @@ const SpellingBeeGame = () => {
   // Handle background music on different screens
   const screen = gameState === 'playing' ? 'game' : 'menu';
   const trackVariant = screen === 'game' ? 'instrumental' : 'vocal';
-  useMusic(musicStyle, trackVariant, musicVolume, soundEnabled, screen);
+  useMusic(musicStyle, trackVariant, musicVolume, soundEnabled, screen, isMusicPlaying);
+
+  const handleSoundEnabledChange = (enabled: boolean) => {
+    setSoundEnabled(enabled);
+
+    if (!enabled) {
+      audioManager.pauseMusic();
+    } else if (isMusicPlaying) {
+      audioManager.resumeMusic();
+    }
+  };
+
+  const handleToggleMusicPlaying = () => {
+    setIsMusicPlaying(prev => {
+      const next = !prev;
+      if (!next) {
+        audioManager.pauseMusic();
+      } else if (soundEnabled) {
+        audioManager.resumeMusic();
+      }
+      return next;
+    });
+  };
 
   if (gameState === 'setup') {
     return (
@@ -141,9 +164,9 @@ const SpellingBeeGame = () => {
         onMusicStyleChange={setMusicStyle}
         onMusicVolumeChange={setMusicVolume}
         soundEnabled={soundEnabled}
-        onSoundEnabledChange={setSoundEnabled}
+        onSoundEnabledChange={handleSoundEnabledChange}
         isMusicPlaying={isMusicPlaying}
-        onToggleMusicPlaying={() => setIsMusicPlaying(prev => !prev)}
+        onToggleMusicPlaying={handleToggleMusicPlaying}
       />
     );
   }

--- a/src/utils/useMusic.ts
+++ b/src/utils/useMusic.ts
@@ -1,175 +1,126 @@
-import { useState, useEffect, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import type { Howl } from 'howler';
+import { audioManager } from './audio.ts';
+import { musicFiles, DEFAULT_STYLE } from '../constants';
+
+type TrackVariant = 'vocal' | 'instrumental';
+type ScreenType = 'menu' | 'game';
+
+type MusicKey = keyof typeof musicFiles;
 
 // Validate volume to be between 0 and 1 and finite
 const validateVolume = (volume: number) => {
   return Number.isFinite(volume) ? Math.min(1, Math.max(0, volume)) : 0.5;
 };
 
-// Check if the audio file is valid
-const checkAudioFile = async (url: string) => {
-  try {
-    const response = await fetch(url, { method: 'HEAD' });
-    if (!response.ok) {
-      throw new Error(`HTTP ${response.status} for ${url}`);
-    }
-    return true;
-  } catch (error) {
-    console.warn(`Audio file not found: ${url}`);
-    return false;
+const buildTrackKey = (style: string, variant: TrackVariant): MusicKey => {
+  const normalizedStyle = style?.toLowerCase().replace(/\s+/g, '_') || DEFAULT_STYLE;
+  const candidateKey = (variant === 'instrumental'
+    ? `${normalizedStyle}_instrumental`
+    : normalizedStyle) as MusicKey;
+
+  if (musicFiles[candidateKey]) {
+    return candidateKey;
   }
+
+  const fallback = (variant === 'instrumental'
+    ? `${DEFAULT_STYLE}_instrumental`
+    : DEFAULT_STYLE) as MusicKey;
+
+  return fallback;
 };
 
-type MusicGenre = 'Funk' | 'Country' | 'Deep Bass' | 'Rock' | 'Jazz' | 'Classical';
-type TrackVariant = 'vocal' | 'instrumental';
-type ScreenType = 'menu' | 'game';
+const registerPlaybackListeners = (
+  howl: Howl | undefined,
+  onPlay: () => void,
+  onStop: () => void
+) => {
+  if (!howl) {
+    return () => {};
+  }
 
-const DEFAULT_GENRE: MusicGenre = 'Funk';
+  howl.on('play', onPlay);
+  howl.on('stop', onStop);
+  howl.on('pause', onStop);
+  howl.on('end', onStop);
+
+  return () => {
+    howl.off('play', onPlay);
+    howl.off('stop', onStop);
+    howl.off('pause', onStop);
+    howl.off('end', onStop);
+  };
+};
 
 const useMusic = (
-  musicStyle: string,
-  trackVariant: TrackVariant,
-  musicVolume: number,
-  soundEnabled: boolean,
-  screen: ScreenType
+  musicStyle: string = DEFAULT_STYLE,
+  trackVariant: TrackVariant = 'vocal',
+  musicVolume: number = 0.7,
+  soundEnabled: boolean = true,
+  screen: ScreenType = 'menu',
+  shouldPlay: boolean = true
 ) => {
   const [isPlaying, setIsPlaying] = useState<boolean>(false);
   const [currentVolume, setCurrentVolume] = useState<number>(validateVolume(musicVolume));
   const [currentTrack, setCurrentTrack] = useState<string>('');
-  const audioContextRef = useRef<AudioContext | null>(null);
-  const audioBufferRef = useRef<AudioBuffer | null>(null);
-  const sourceNodeRef = useRef<AudioBufferSourceNode | null>(null);
-  const gainNodeRef = useRef<GainNode | null>(null);
+  const previousTrackKey = useRef<MusicKey | null>(null);
+
+  const trackKey = useMemo(
+    () => buildTrackKey(musicStyle || DEFAULT_STYLE, trackVariant),
+    [musicStyle, trackVariant]
+  );
 
   useEffect(() => {
-    // Initialize audio context
-    const AudioContext = window.AudioContext || (window as any).webkitAudioContext;
-    audioContextRef.current = new AudioContext();
+    const validatedVolume = validateVolume(musicVolume);
+    setCurrentVolume(validatedVolume);
+    audioManager.setMusicVolume(validatedVolume);
+  }, [musicVolume]);
 
-    return () => {
-      // Cleanup
-      if (sourceNodeRef.current) {
-        sourceNodeRef.current.stop();
-        sourceNodeRef.current.disconnect();
-      }
-      if (gainNodeRef.current) {
-        gainNodeRef.current.disconnect();
-      }
-      if (audioContextRef.current) {
-        audioContextRef.current.close();
-      }
-    };
-  }, []);
-
-  // Function to build the correct audio file path
-  const buildAudioPath = (style: string, variant: TrackVariant): string => {
-    const genre = style.toLowerCase().replace(' ', '-');
-    const isInstrumental = variant === 'instrumental';
-    const suffix = isInstrumental ? '-instrumental' : '';
-    return `assets/audio/spelling-bee-${genre}${suffix}.mp3`;
-  };
-
-  // Effect to handle music changes based on screen and settings
   useEffect(() => {
-    if (!soundEnabled) {
-      stop();
+    const trackSource = musicFiles[trackKey];
+    if (!trackSource) {
+      setIsPlaying(false);
       return;
     }
 
-    const targetTrack = buildAudioPath(musicStyle, trackVariant);
-    
-    if (currentTrack !== targetTrack) {
-      setCurrentTrack(targetTrack);
-      if (isPlaying) {
-        play(targetTrack);
-      }
-    }
-  }, [musicStyle, trackVariant, soundEnabled, screen]);
+    setCurrentTrack(trackSource);
 
-  // Effect to handle volume changes
-  useEffect(() => {
-    setCurrentVolume(validateVolume(musicVolume));
-    if (gainNodeRef.current) {
-      gainNodeRef.current.gain.value = validateVolume(musicVolume);
-    }
-  }, [musicVolume]);
-
-  // Auto-start music when enabled
-  useEffect(() => {
-    if (soundEnabled && currentTrack && !isPlaying) {
-      play(currentTrack);
-    }
-  }, [soundEnabled, currentTrack]);
-
-  const loadAudio = async (url: string) => {
-    if (!audioContextRef.current) return null;
-
-    try {
-      // Validate the audio file first
-      const isValid = await checkAudioFile(url);
-      if (!isValid) {
-        throw new Error(`Invalid audio file: ${url}`);
-      }
-
-      const response = await fetch(url);
-      const arrayBuffer = await response.arrayBuffer();
-      return await audioContextRef.current.decodeAudioData(arrayBuffer);
-    } catch (error) {
-      console.error('Error loading audio:', error);
-      return null;
-    }
-  };
-
-  const play = async (url: string) => {
-    if (!audioContextRef.current) return;
-
-    // Stop any currently playing audio
-    stop();
-
-    // Load new audio
-    const audioBuffer = await loadAudio(url);
-    if (!audioBuffer) return;
-
-    audioBufferRef.current = audioBuffer;
-
-    // Create and configure nodes
-    sourceNodeRef.current = audioContextRef.current.createBufferSource();
-    sourceNodeRef.current.buffer = audioBufferRef.current;
-
-    gainNodeRef.current = audioContextRef.current.createGain();
-    gainNodeRef.current.gain.value = currentVolume;
-
-    // Connect nodes
-    sourceNodeRef.current.connect(gainNodeRef.current);
-    gainNodeRef.current.connect(audioContextRef.current.destination);
-
-    // Start playing
-    sourceNodeRef.current.start(0);
-    setIsPlaying(true);
-
-    // Handle end of playback
-    sourceNodeRef.current.onended = () => {
+    if (!soundEnabled || !shouldPlay) {
+      audioManager.pauseMusic();
       setIsPlaying(false);
+      return;
+    }
+
+    if (!audioManager.getMusic(trackKey)) {
+      audioManager.loadMusic(trackKey, trackSource, { preload: true, loop: true });
+    }
+
+    const musicInstance = audioManager.getMusic(trackKey);
+    const cleanupListeners = registerPlaybackListeners(
+      musicInstance,
+      () => setIsPlaying(true),
+      () => setIsPlaying(false)
+    );
+
+    // If the track changed, play the new one. Otherwise attempt to resume.
+    if (previousTrackKey.current !== trackKey) {
+      const id = audioManager.playMusic(trackKey, { loop: true });
+      setIsPlaying(id !== null);
+      previousTrackKey.current = trackKey;
+    } else if (musicInstance && !musicInstance.playing()) {
+      audioManager.resumeMusic();
+    }
+
+    return () => {
+      cleanupListeners();
+
+      if (screen === 'menu') {
+        audioManager.stopMusic();
+        previousTrackKey.current = null;
+      }
     };
-  };
+  }, [trackKey, soundEnabled, shouldPlay, screen]);
 
-  const stop = () => {
-    if (sourceNodeRef.current) {
-      sourceNodeRef.current.stop();
-      sourceNodeRef.current.disconnect();
-      sourceNodeRef.current = null;
-    }
-    setIsPlaying(false);
-  };
-
-  const setVolume = (newVolume: number) => {
-    const validatedVolume = validateVolume(newVolume);
-    setCurrentVolume(validatedVolume);
-    if (gainNodeRef.current) {
-      gainNodeRef.current.gain.value = validatedVolume;
-    }
-  };
-
-  // The hook is used as a side effect, so we can return minimal info for debugging
   return {
     isPlaying,
     currentTrack,


### PR DESCRIPTION
## Summary
- replace the Web Audio implementation in `useMusic` with audio manager driven playback that preloads, resumes, and cleans up music tracks
- tie the SpellingBeeGame screen-level audio toggles into the audio manager so play/pause actions immediately affect the active music
- update the `useMusic` unit tests to mock the audio manager and verify playback, pause, and resume behavior

## Testing
- npm run test:unit
- npm test -- useMusic.test.ts *(Playwright step reports "No tests found")*

------
https://chatgpt.com/codex/tasks/task_e_68e5930f7a548332b27dff66986efbb0