### PR TITLE
Fix theme selector to toggle Tailwind dark mode

### DIFF
--- a/src/GameScreen.tsx
+++ b/src/GameScreen.tsx
@@ -19,6 +19,7 @@ import { getContextualMascot } from './utils/mascot';
 import ParticipantStats from './components/ParticipantStats';
 import { HelpShop } from './components/HelpShop';
 import { saveGameState, generateGameId, autoSaveGameState, type SavedGameState } from './utils/gameStateManager';
+import { applyThemeClass } from './utils/theme';
 
 const musicStyles = ['Funk', 'Country', 'Deep Bass', 'Rock', 'Jazz', 'Classical'];
 
@@ -146,9 +147,8 @@ const GameScreen: React.FC<GameScreenProps> = ({
   }, [currentWord, isPaused, letters]);
 
   React.useEffect(() => {
-    document.body.classList.remove('theme-light', 'theme-dark', 'theme-honeycomb');
-    document.body.classList.add(`theme-${theme}`);
-    localStorage.setItem('theme', theme);
+    const normalized = applyThemeClass(theme);
+    localStorage.setItem('theme', normalized);
   }, [theme]);
 
   // Auto-save game state when key properties change

--- a/src/SetupScreen.tsx
+++ b/src/SetupScreen.tsx
@@ -4,6 +4,7 @@ import { IMAGE_ASSETS } from './assets';
 import { parseWordList as parseWordListUtil } from './utils/parseWordList';
 import { getMascotImage } from './utils/mascot';
 import { hasSavedGame, getSavedGameInfo, loadGameState, clearSavedGame } from './utils/gameStateManager';
+import { applyThemeClass, type ThemeName } from './utils/theme';
 
 // Gather available music styles.
 // This is hardcoded as a workaround for build tools that don't support `import.meta.glob`.
@@ -57,7 +58,7 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
   const [musicVolume, setMusicVolume] = useState<number>(() => parseFloat(localStorage.getItem('musicVolume') ?? '1'));
   const [initialDifficulty, setInitialDifficulty] = useState(0);
   const [progressionSpeed, setProgressionSpeed] = useState(1);
-  const [theme, setTheme] = useState('light');
+  const [theme, setTheme] = useState<ThemeName>('light');
   const [teacherMode, setTeacherMode] = useState<boolean>(() => localStorage.getItem('teacherMode') === 'true');
   const [aiGrade, setAiGrade] = useState(5);
   const [aiTopic, setAiTopic] = useState('');
@@ -68,11 +69,6 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
   // Saved game state
   const [savedGameAvailable, setSavedGameAvailable] = useState(false);
   const [savedGameInfo, setSavedGameInfo] = useState<any>(null);
-
-  const applyTheme = (t: string) => {
-    document.body.classList.remove('theme-light', 'theme-dark', 'theme-honeycomb');
-    document.body.classList.add(`theme-${t}`);
-  };
 
   useEffect(() => {
     if (teacherMode) {
@@ -90,10 +86,10 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
     if (savedStudents) try { setStudents(JSON.parse(savedStudents).map((s: Participant) => ({ ...s, avatar: s.avatar || getRandomAvatar() }))); } catch {}
     const savedTheme = localStorage.getItem('theme');
     if (savedTheme) {
-      setTheme(savedTheme);
-      applyTheme(savedTheme);
+      const normalized = applyThemeClass(savedTheme);
+      setTheme(normalized);
     } else {
-      applyTheme(theme);
+      applyThemeClass(theme);
     }
   }, []);
 
@@ -510,7 +506,7 @@ const SetupScreen: React.FC<SetupScreenProps> = ({ onStartGame, onAddCustomWords
             </div>
             <div className="bg-white/10 p-6 rounded-lg">
                 <h2 className="text-2xl font-bold mb-4">Theme 🎨</h2>
-                <select value={theme} onChange={e => { const t = e.target.value; setTheme(t); localStorage.setItem('theme', t); applyTheme(t); }} className="p-2 rounded-md bg-white/20 text-white">
+                <select value={theme} onChange={e => { const normalized = applyThemeClass(e.target.value); setTheme(normalized); localStorage.setItem('theme', normalized); }} className="p-2 rounded-md bg-white/20 text-white">
                     <option value="light">Light</option>
                     <option value="dark">Dark</option>
                     <option value="honeycomb">Honeycomb</option>

--- a/src/components/GameOptions.tsx
+++ b/src/components/GameOptions.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect } from 'react';
+import { applyThemeClass } from '../utils/theme';
 
 interface OptionsState {
   soundEnabled: boolean;
@@ -20,11 +21,6 @@ interface GameOptionsProps {
 }
 
 const GameOptions: React.FC<GameOptionsProps> = ({ options, setOptions }) => {
-  const applyTheme = (t: string) => {
-    document.body.classList.remove('theme-light', 'theme-dark', 'theme-honeycomb');
-    document.body.classList.add(`theme-${t}`);
-  };
-
   useEffect(() => {
     localStorage.setItem('soundEnabled', String(options.soundEnabled));
   }, [options.soundEnabled]);
@@ -51,8 +47,8 @@ const GameOptions: React.FC<GameOptionsProps> = ({ options, setOptions }) => {
   }, [options.teacherMode]);
 
   useEffect(() => {
-    applyTheme(options.theme);
-    localStorage.setItem('theme', options.theme);
+    const normalized = applyThemeClass(options.theme);
+    localStorage.setItem('theme', normalized);
   }, [options.theme]);
 
   return (

--- a/src/spelling-bee-game.tsx
+++ b/src/spelling-bee-game.tsx
@@ -8,6 +8,7 @@ import AchievementsScreen from './AchievementsScreen';
 import HistoryScreen from './HistoryScreen';
 import ShopScreen from './ShopScreen';
 import useMusic from './utils/useMusic';
+import { applyThemeClass } from './utils/theme';
 import { AudioProvider } from './AudioContext';
 import { HelpSystemProvider } from './contexts/HelpSystemContext';
 
@@ -108,8 +109,7 @@ const SpellingBeeGame = () => {
   useEffect(() => {
     const savedTheme = localStorage.getItem('theme');
     if (savedTheme) {
-      document.body.classList.remove('theme-light', 'theme-dark', 'theme-honeycomb');
-      document.body.classList.add(`theme-${savedTheme}`);
+      applyThemeClass(savedTheme);
     }
   }, []);
 

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,0 +1,35 @@
+const SUPPORTED_THEMES = ['light', 'dark', 'honeycomb'] as const;
+
+export type ThemeName = (typeof SUPPORTED_THEMES)[number];
+
+const BODY_THEMES = SUPPORTED_THEMES.map(theme => `theme-${theme}`);
+
+/**
+ * Applies the selected theme by updating the body classes and Tailwind "dark" mode state.
+ */
+export const applyThemeClass = (theme: string): ThemeName => {
+  if (typeof document === 'undefined') {
+    return 'light';
+  }
+
+  const normalized = (SUPPORTED_THEMES.includes(theme as ThemeName) ? theme : 'light') as ThemeName;
+
+  const body = document.body;
+  const root = document.documentElement;
+
+  body.classList.remove(...BODY_THEMES);
+  body.classList.add(`theme-${normalized}`);
+
+  if (normalized === 'dark') {
+    root.classList.add('dark');
+    root.setAttribute('data-theme', 'dark');
+  } else {
+    root.classList.remove('dark');
+    root.setAttribute('data-theme', 'light');
+  }
+
+  root.classList.toggle('theme-honeycomb', normalized === 'honeycomb');
+
+  return normalized;
+};
+


### PR DESCRIPTION
## Summary
- add a shared theme helper that toggles body theme classes and Tailwind's dark mode flag
- update the setup screen, in-game screen, and options panel to use the helper when applying or persisting the selected theme
- ensure the root component reapplies the stored theme on load so the selection survives navigation

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e595e5572083329278d8114feb76e6